### PR TITLE
Deprecate role param.

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -145,7 +145,7 @@ func (u *promUnifi) Run(c poller.Collect) error {
 func (u *promUnifi) ScrapeHandler(w http.ResponseWriter, r *http.Request) {
 	t := &target{u: u, Filter: &poller.Filter{
 		Name: r.URL.Query().Get("input"),  // "unifi"
-		Path: r.URL.Query().Get("target"), // NEW (target): "https://127.0.0.1:8443"
+		Path: r.URL.Query().Get("target"), // url: "https://127.0.0.1:8443"
 	}}
 
 	if t.Name == "" {

--- a/collector.go
+++ b/collector.go
@@ -150,15 +150,20 @@ func (u *promUnifi) ScrapeHandler(w http.ResponseWriter, r *http.Request) {
 	}}
 
 	if t.Name == "" {
-		u.Collector.LogErrorf("input parameter missing on scrape from %v", r.RemoteAddr)
-		http.Error(w, `'input' parameter must be specified (try "unifi")`, 400)
-
-		return
+		t.Name = "unifi" // the default
 	}
 
-	if t.Role == "" && t.Path == "" {
-		u.Collector.LogErrorf("role and path parameters missing on scrape from %v", r.RemoteAddr)
-		http.Error(w, "'role' OR 'path' parameter must be specified: configured role OR unconfigured url", 400)
+	if t.Role != "" {
+		u.Collector.LogErrorf("deprecated 'role' parameter used; update your config to use 'path'")
+
+		if t.Path == "" {
+			t.Path = t.Role
+		}
+	}
+
+	if t.Path == "" {
+		u.Collector.LogErrorf("path parameter missing on scrape from %v", r.RemoteAddr)
+		http.Error(w, "'path' parameter must be specified: configured OR unconfigured url", 400)
 
 		return
 	}

--- a/collector.go
+++ b/collector.go
@@ -225,12 +225,7 @@ func (u *promUnifi) collect(ch chan<- prometheus.Metric, filter *poller.Filter) 
 
 	ok := false
 
-	if filter == nil {
-		r.Metrics, ok, err = u.Collector.Metrics()
-	} else {
-		r.Metrics, ok, err = u.Collector.MetricsFrom(filter)
-	}
-
+	r.Metrics, ok, err = u.Collector.MetricsFrom(filter)
 	r.Fetch = time.Since(r.Start)
 
 	if err != nil {


### PR DESCRIPTION
- Deprecates the role parameter and automatically sets input parameter to "unifi". Fixes https://github.com/unifi-poller/unifi-poller/issues/190. Goes with https://github.com/unifi-poller/inputunifi/pull/2. 